### PR TITLE
Add dynamic shortcode for auto-hiding workshop links for different web properties

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -43,6 +43,7 @@ weight: 1
                     </a>
                 </div>
         </div>
+        {{% includeContentSection "azure" %}}
         <div class="col-lg-6 col-sm-6 mb-4">
                 <div class="card text-center">
                     <a href="./azure.html">
@@ -56,5 +57,6 @@ weight: 1
                     </a>
                 </div>
         </div>
-    </div>
+        </div>
+        {{% /includeContentSection %}}
 </div>

--- a/layouts/shortcodes/includeContentSection.html
+++ b/layouts/shortcodes/includeContentSection.html
@@ -1,0 +1,3 @@
+{{ if fileExists (.Get 0) }}
+<span>{{ .Inner }}</span>
+{{ end }}


### PR DESCRIPTION
We host workshops from this repo on multiple web properties.

This shortcode will dynamically allow links to workshops to be hidden on properties where that content is not necessary, without needing to maintain multiple versions of the homepage.